### PR TITLE
ci: disable testing tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go: 
- - 1.7.1
- - tip
+ - 1.8
 
 script:
  - go test -race -v ./...


### PR DESCRIPTION
It is failing the tests. This may actually be an underlying issue in the tests,
but not a big deal to fix now.