### PR TITLE
Handle is blocking

### DIFF
--- a/async.go
+++ b/async.go
@@ -1,0 +1,17 @@
+package jsonrpc2
+
+import "context"
+
+// AsyncHandler wraps a Handler such that it each request is handled in its
+// own goroutine. It is a convenience wrapper.
+func AsyncHandler(h Handler) Handler {
+	return asyncHandler{h}
+}
+
+type asyncHandler struct {
+	Handler
+}
+
+func (h asyncHandler) Handle(ctx context.Context, conn *Conn, req *Request) {
+	go h.Handler.Handle(ctx, conn, req)
+}

--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -226,7 +226,10 @@ const (
 
 // Handler handles JSON-RPC requests and notifications.
 type Handler interface {
-	// Handle is called to handle a request.
+	// Handle is called to handle a request. No other requests are handled
+	// until it returns. If you do not require strict ordering behaviour
+	// of received RPCs, it is suggested to wrap your handler in
+	// AsyncHandler.
 	Handle(context.Context, *Conn, *Request)
 }
 
@@ -498,7 +501,7 @@ func (c *Conn) readMessages(ctx context.Context) {
 			if c.onRecv != nil {
 				c.onRecv(m.request, nil)
 			}
-			go c.h.Handle(ctx, c, m.request)
+			c.h.Handle(ctx, c, m.request)
 
 		case m.response != nil:
 			resp := m.response


### PR DESCRIPTION
We have strict ordering requirements of how we handle FileSystem requests in
LSP. As such relying on the ordering the goroutine scheduler runs requests in
leads to potential out of order mutations to the FS. As such we update the
jsonrpc2 implementation to by default block until Handle returns (note it can
still respond to the request at a later stage). For more simple use cases we
provide the AsyncHandler which will work like the previous implementation.