### PR TITLE
Response: Add omitempty tag for Result

### DIFF
--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -128,7 +128,7 @@ func (r *Request) SetMeta(v interface{}) error {
 // http://www.jsonrpc.org/specification#response_object.
 type Response struct {
 	ID     ID               `json:"id"`
-	Result *json.RawMessage `json:"result"`
+	Result *json.RawMessage `json:"result,omitempty"`
 	Error  *Error           `json:"error,omitempty"`
 
 	// Meta optionally provides metadata to include in the response.


### PR DESCRIPTION
The 'result' key MUST be unset according when the error key is set.
This is not what is happening right now. When the error is set,
"result":null is returned in the response payload. This patch is fixing
the issue by adding omitempty for the result field.

Fixes #13 