### PR TITLE
remove content type from vscode object codec

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -120,10 +120,7 @@ func (VSCodeObjectCodec) WriteObject(stream io.Writer, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(stream, "Content-Length: %d\r\n", len(data)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprint(stream, "Content-Type: application/vscode-jsonrpc; charset=utf8\r\n\r\n"); err != nil {
+	if _, err := fmt.Fprintf(stream, "Content-Length: %d\r\n\r\n", len(data)); err != nil {
 		return err
 	}
 	if _, err := stream.Write(data); err != nil {


### PR DESCRIPTION
It is optional, and we are sending the default value. https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#header-part

Notably the rust language server doesn't support receiving it.