### PR TITLE
support for go 1.12+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sourcegraph/jsonrpc2
 
-go 1.13
+go 1.12
 
 require github.com/gorilla/websocket v1.4.1


### PR DESCRIPTION
@sqs recent go.mod addition will break compatibility for go 1.12 (currently supported) version