### PR TITLE
Add message serializer

### DIFF
--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -507,7 +507,7 @@ func (c *Conn) DisconnectNotify() <-chan struct{} {
 
 func (c *Conn) readMessages(ctx context.Context) {
 	var err error
-	for err == nil {
+	for {
 		var m anyMessage
 		err = c.stream.ReadObject(&m)
 		if err != nil {

--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -583,6 +583,8 @@ func (c *Conn) readMessages(ctx context.Context) {
 	close(c.disconnect)
 }
 
+var MessageSerializer func([]byte) ([]byte, error)
+
 // call represents a JSON-RPC call over its entire lifecycle.
 type call struct {
 	request  *Request
@@ -634,6 +636,15 @@ func (m *anyMessage) UnmarshalJSON(data []byte) error {
 		isRequest = mIsRequest
 		isResponse = mIsResponse
 		return nil
+	}
+
+	if MessageSerializer != nil {
+		var err error
+
+		data, err = MessageSerializer(data)
+		if err != nil {
+			return err
+		}
 	}
 
 	if isArray := len(data) > 0 && data[0] == '['; isArray {


### PR DESCRIPTION
### Problem summary

Recently I tried to use [Binance](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md) API. The problem was that `anyMessage` could not unmarshal the payload and I came across this error:
```jsonrpc2: unable to determine message type (request or response)```
Well, `anyMessage` unmarshaller worked fine but the problem was that there was no `method` in the payload!

An example of payload:
```json
{
  "e": "kline",
  "E": 123456789,
  "s": "BNBBTC",
  "k": {
    "t": 123400000,
    "T": 123460000,
    "s": "BNBBTC",
    ...
  }
}
```

### Solution
We need a serializer func that call before unmarshal `anyMessage` data.
I tried to put this serializer in `anyMessage` struct but it was not possible :d
That's why I defined a global serializer and the user can override it.