### PR TITLE
Guard against nil handlers

### DIFF
--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -355,6 +355,7 @@ func (id *ID) UnmarshalJSON(data []byte) error {
 type Conn struct {
 	stream ObjectStream
 
+	// If Handler is nil, incoming requests are skipped
 	h Handler
 
 	mu       sync.Mutex
@@ -620,7 +621,11 @@ func (c *Conn) readMessages(ctx context.Context) {
 			for _, onRecv := range c.onRecv {
 				onRecv(m.request, nil)
 			}
-			c.h.Handle(ctx, c, m.request)
+
+			// If handler is not nil, handle the request.
+			if c.h != nil {
+				c.h.Handle(ctx, c, m.request)
+			}
 
 		case m.response != nil:
 			resp := m.response


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jsonrpc2/issues/53

Allows callers to pass a `nil` handler like so:
```
jsonrpc2.NewConn(ctx, stream, nil)
```

This removes the need for users of the pkg to need to create noop handlers and pass nil instead.

Note: Another alternative to this is to expose a `NoopHandler` from the pkg that people can use instead, happy to go that route as well.