### PR TITLE
Expose a NoopHandler

### DIFF
--- a/call_opt_test.go
+++ b/call_opt_test.go
@@ -22,7 +22,7 @@ func TestPickID(t *testing.T) {
 		}
 	})
 	connA := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(a, jsonrpc2.VSCodeObjectCodec{}), handler)
-	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), noopHandler{})
+	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), jsonrpc2.NoopHandler{})
 	defer connA.Close()
 	defer connB.Close()
 
@@ -81,7 +81,7 @@ func TestStringID(t *testing.T) {
 		}
 	})
 	connA := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(a, jsonrpc2.VSCodeObjectCodec{}), handler)
-	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), noopHandler{})
+	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), jsonrpc2.NoopHandler{})
 	defer connA.Close()
 	defer connB.Close()
 
@@ -131,7 +131,7 @@ func TestExtraField(t *testing.T) {
 		}
 	})
 	connA := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(a, jsonrpc2.VSCodeObjectCodec{}), handler)
-	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), noopHandler{})
+	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), jsonrpc2.NoopHandler{})
 	defer connA.Close()
 	defer connB.Close()
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -50,7 +50,7 @@ func TestPlainObjectCodec(t *testing.T) {
 	connA := jsonrpc2.NewConn(
 		context.Background(),
 		jsonrpc2.NewBufferedStream(cA, jsonrpc2.PlainObjectCodec{}),
-		noopHandler{},
+		jsonrpc2.NoopHandler{},
 	)
 	defer connA.Close()
 

--- a/conn_opt_test.go
+++ b/conn_opt_test.go
@@ -26,13 +26,13 @@ func TestSetLogger(t *testing.T) {
 	connA := jsonrpc2.NewConn(
 		ctx,
 		jsonrpc2.NewBufferedStream(a, jsonrpc2.VSCodeObjectCodec{}),
-		noopHandler{},
+		jsonrpc2.NoopHandler{},
 		jsonrpc2.SetLogger(logger),
 	)
 	connB := jsonrpc2.NewConn(
 		ctx,
 		jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}),
-		noopHandler{},
+		jsonrpc2.NoopHandler{},
 	)
 	defer connA.Close()
 	defer connB.Close()

--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -303,6 +303,12 @@ type Handler interface {
 	Handle(context.Context, *Conn, *Request)
 }
 
+// NoopHandler is a Handler that does nothing. It is useful for 
+// creating a Handler that can be used as a default handler. It is also
+// useful for testing.
+type NoopHandler struct {}
+func (NoopHandler) Handle(ctx context.Context, conn *Conn, req *Request) {}
+
 // ID represents a JSON-RPC 2.0 request ID, which may be either a
 // string or number (or null, which is unsupported).
 type ID struct {

--- a/jsonrpc2_test.go
+++ b/jsonrpc2_test.go
@@ -265,7 +265,7 @@ func TestHandlerBlocking(t *testing.T) {
 		wg.Done()
 	})
 	connA := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(a, jsonrpc2.VSCodeObjectCodec{}), handler)
-	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), noopHandler{})
+	connB := jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(b, jsonrpc2.VSCodeObjectCodec{}), jsonrpc2.NoopHandler{})
 	defer connA.Close()
 	defer connB.Close()
 
@@ -286,10 +286,6 @@ func TestHandlerBlocking(t *testing.T) {
 		}
 	}
 }
-
-type noopHandler struct{}
-
-func (noopHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {}
 
 type readWriteCloser struct {
 	read, write func(p []byte) (n int, err error)
@@ -348,7 +344,7 @@ func TestConn_DisconnectNotify_Close_async(t *testing.T) {
 }
 
 func TestConn_Close_waitingForResponse(t *testing.T) {
-	c := jsonrpc2.NewConn(context.Background(), jsonrpc2.NewBufferedStream(&readWriteCloser{eof, eof}, jsonrpc2.VarintObjectCodec{}), noopHandler{})
+	c := jsonrpc2.NewConn(context.Background(), jsonrpc2.NewBufferedStream(&readWriteCloser{eof, eof}, jsonrpc2.VarintObjectCodec{}), jsonrpc2.NoopHandler{})
 	done := make(chan struct{})
 	go func() {
 		if err := c.Call(context.Background(), "m", nil, nil); err != jsonrpc2.ErrClosed {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jsonrpc2/issues/53

It takes a different approach than what I recommend in the issue, prev PR was not really going to solve the problem since it would be hard to detect a `nil` interface: https://github.com/sourcegraph/jsonrpc2/pull/54

This PR takes a different approach, it exposes a `NoopHandler` that can be used as a default handler by callers that do not care for incoming requests and don't need to define one themselves.

We already had this concept in tests, so updated all of those call sites to use the exposed type instead.