### PR TITLE
[WIP] Adjust Handler interface and support middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/async.go
+++ b/async.go
@@ -1,7 +1,5 @@
 package jsonrpc2
 
-import "context"
-
 // AsyncHandler wraps a Handler such that each request is handled in its own
 // goroutine. It is a convenience wrapper.
 func AsyncHandler(h Handler) Handler {
@@ -12,6 +10,6 @@ type asyncHandler struct {
 	Handler
 }
 
-func (h asyncHandler) Handle(ctx context.Context, conn *Conn, req *Request) {
-	go h.Handler.Handle(ctx, conn, req)
+func (h asyncHandler) Handle(conn *Conn, req *Request) {
+	go h.Handler.Handle(conn, req)
 }

--- a/call_opt_test.go
+++ b/call_opt_test.go
@@ -16,8 +16,8 @@ func TestPickID(t *testing.T) {
 	defer a.Close()
 	defer b.Close()
 
-	handler := handlerFunc(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
-		if err := conn.Reply(ctx, req.ID, fmt.Sprintf("hello, #%s: %s", req.ID, *req.Params)); err != nil {
+	handler := handlerFunc(func(conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+		if err := conn.Reply(req.Context(), req.ID, fmt.Sprintf("hello, #%s: %s", req.ID, *req.Params)); err != nil {
 			t.Error(err)
 		}
 	})
@@ -61,7 +61,7 @@ func TestStringID(t *testing.T) {
 	defer a.Close()
 	defer b.Close()
 
-	handler := handlerFunc(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	handler := handlerFunc(func(conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
 		replyWithError := func(msg string) {
 			respErr := &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidRequest, Message: msg}
 			if err := conn.ReplyWithError(ctx, req.ID, respErr); err != nil {
@@ -100,7 +100,7 @@ func TestExtraField(t *testing.T) {
 	defer a.Close()
 	defer b.Close()
 
-	handler := handlerFunc(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	handler := handlerFunc(func(conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
 		replyWithError := func(msg string) {
 			respErr := &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidRequest, Message: msg}
 			if err := conn.ReplyWithError(ctx, req.ID, respErr); err != nil {

--- a/codec_test.go
+++ b/codec_test.go
@@ -56,13 +56,13 @@ func TestPlainObjectCodec(t *testing.T) {
 
 	// echoHandler unmarshals the request's params object and echos the object
 	// back as the response's result.
-	var echoHandler handlerFunc = func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	var echoHandler handlerFunc = func(conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
 		msg := &Message{}
 		if err := json.Unmarshal(*req.Params, msg); err != nil {
-			conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidRequest, Message: err.Error()})
+			conn.ReplyWithError(req.Context(), req.ID, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidRequest, Message: err.Error()})
 			return
 		}
-		conn.Reply(ctx, req.ID, msg)
+		conn.Reply(req.Context(), req.ID, msg)
 	}
 	connB := jsonrpc2.NewConn(
 		context.Background(),

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sourcegraph/jsonrpc2
 
 go 1.12
 
-require github.com/gorilla/websocket v1.4.1
+require github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
-github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,38 @@
+package jsonrpc2
+
+// Handler handles JSON-RPC requests and notifications.
+type Handler interface {
+	// Handle is called to handle a request. No other requests are handled
+	// until it returns. If you do not require strict ordering behavior
+	// of received RPCs, it is suggested to wrap your handler in
+	// AsyncHandler.
+	Handle(*Conn, *Request)
+}
+
+type HandlerFunc func(*Conn, *Request)
+
+func (f HandlerFunc) Handle(conn *Conn, req *Request) {
+	f(conn, req)
+}
+
+type Middleware func(Handler) Handler
+
+type chain struct {
+	ms []Middleware
+}
+
+func Chain(middleware ...Middleware) chain {
+	return chain{ms: append([]Middleware(nil), middleware...)}
+}
+
+func (c chain) Then(h Handler) Handler {
+	if h == nil {
+		panic("nil handler")
+	}
+
+	for i := range c.ms {
+		h = c.ms[len(c.ms)-1-i](h)
+	}
+
+	return h
+}


### PR DESCRIPTION
1. This will be a **breaking change** since the original `jsonrpc2.Handler` interface will be changed from

```go
type Handler interface {
    Handle(context.Context, *Conn, *Request)
}
```

to

```go
type Handler interface {
    Handle(*Conn, *Request)
}
```

2. In order to pass down `context` more easily from handlers to handlers, the `context` will be attached to `Request`. And the following new methods will be added to `Request`:

```go
Context() context.Context
WithContext(newContext context.Context) *Request
```

3. A new function `Chain(middleware ...Middleware)` will be added for writing middlewares.

```go
func MyHandler(conn *Conn, r *Request) {
    // ...
}

func NoInternalMethods(next Handler) Handler {
    // hide "internal_*" methods from external users
}

func RequireSignature(next Handler) Handler {
    // extra field "signature" is required
}

handler := Chain(NoInternalMethods, RequireSignature).Then(MyHandler)
```

I hope this could help.