### PR TITLE
[#57] Fix and deprecate PlainObjectCodec

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -169,8 +169,9 @@ func (VSCodeObjectCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
 	return json.NewDecoder(io.LimitReader(stream, int64(contentLength))).Decode(v)
 }
 
-// DEPRECATED: use NewPlainObjectStream
 // PlainObjectCodec reads/writes plain JSON-RPC 2.0 objects without a header.
+//
+// Deprecated: use NewPlainObjectStream
 type PlainObjectCodec struct {
 	decoder *json.Decoder
 	encoder *json.Encoder
@@ -192,6 +193,7 @@ func (c PlainObjectCodec) ReadObject(stream *bufio.Reader, v interface{}) error 
 	return json.NewDecoder(stream).Decode(v)
 }
 
+// plainObjectStream reads/writes plain JSON-RPC 2.0 objects without a header.
 type plainObjectStream struct {
 	conn    io.Closer
 	decoder *json.Decoder
@@ -199,7 +201,6 @@ type plainObjectStream struct {
 	mu      sync.Mutex
 }
 
-// plainObjectStream reads/writes plain JSON-RPC 2.0 objects without a header.
 func NewPlainObjectStream(conn io.ReadWriteCloser) ObjectStream {
 	os := &plainObjectStream{conn: conn}
 	os.encoder = json.NewEncoder(conn)


### PR DESCRIPTION
This change fixes a bug that causes PlainObjectCodec to
lose additional messages from stream. json.Decoder has
an internal buffer that reads more than one message, but
is discarded after every use. Now PlainObjectCodec reuses
encoder and decoder within a buffered stream, however
using it directly in your code retains the old, incorrect
behaviour.

A user should now use plainObjectStream if he needs
plain JSON-RPC 2.0 stream without headers.
`NewPlainObjectStream` method has been added for this reason.

fixes #57