### PR TITLE
Pin staticcheck version to v0.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get dependencies
         run: go get -t -v ./...
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
       - name: Lint
         run: staticcheck -checks=all ./...
       - name: Test


### PR DESCRIPTION
The CI pipeline has been broken in this project for some time because the latest version of staticcheck is not compatible with every version of Go. Through trial and error, it was discovered that staticcheck v0.2.2 is the latest version that is compatible with Go 1.16.

The authors of staticcheck also recommend pinning the version in CI pipelines to prevent unintentional breakage of the build [1].

References
[1]: https://staticcheck.io/docs/running-staticcheck/ci/github-actions/#version