### PR TITLE
ci: set minimal permissions to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -1,6 +1,10 @@
 name: LSIF
 on:
   - push
+
+permissions:
+  contents: read
+
 jobs:
   lsif-go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #72

On the [lsif.yml](https://github.com/sourcegraph/jsonrpc2/blob/master/.github/workflows/lsif.yml) file I couldn't be 100% sure on the permissions required on the lsif-go job, so I let only with `contents: read` for now -- let me know if this should be changed.

Note that the permissions defined on the [line 5](https://github.com/sourcegraph/jsonrpc2/compare/master...diogoteles08:jsonrpc2:master?expand=1#diff-ec41b80d233edd86dd5759adb6cb14e5a0a9d5d7eb6e849000b398c4dd143310R5) will be the same permissions granted on the [line 17](https://github.com/sourcegraph/jsonrpc2/compare/master...diogoteles08:jsonrpc2:master?expand=1#diff-ec41b80d233edd86dd5759adb6cb14e5a0a9d5d7eb6e849000b398c4dd143310R17), as the `secrets.GITHUB_TOKEN` passed as parameter is the same token that will be used to run the workflow in general.