### PR TITLE
Docs: Create Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,3 @@ If you have discovered a security vulnerability in this project, please report i
 
 Please disclose it privately via email to security@sourcegraph.com. We will work with you to understand and resolve the issue promptly.
 
-This project is maintained by a team of volunteers on a reasonable-effort basis. As such, vulnerabilities will be handled and/or disclosed in a best effort base.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to evaluate and fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at our [security advisory](https://github.com/sourcegraph/jsonrpc2/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, vulnerabilities will be handled and/or disclosed in a best effort base.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,6 @@ Security updates are applied only to the latest release.
 
 If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to evaluate and fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
 
-Please disclose it at our [security advisory](https://github.com/sourcegraph/jsonrpc2/security/advisories/new).
+Please disclose it privately via email to security@sourcegraph.com. We will work with you to understand and resolve the issue promptly.
 
 This project is maintained by a team of volunteers on a reasonable-effort basis. As such, vulnerabilities will be handled and/or disclosed in a best effort base.


### PR DESCRIPTION
Closes #74

I've created the SECURITY.md file following a GitHub's template and considering that you'd request that users report vulnerabilities through the [security advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability), which is a handy new GitHub feature, but it's still in beta and **has to be manually enabled by a maintainer**.

If you're interested in this feature, you can activate it following this steps:

1. Click on this [link](https://github.com/sourcegraph/jsonrpc2/settings/security_analysis) to go to Code security & analysis section on your repo's settings
2. Click "Enable" for "Private vulnerability reporting (Beta)"

However, if you'd rather not use this feature, you can also request users to report vulnerabilities to an email. If that's the case, let me know which email you would like to receive the reports and I can submit the change.

Additionally, feel free to edit or suggest any changes to this document, it is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.