### PR TITLE
CI: Enable dependabot to keep CI up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #77 

Reminder: as mentioned on the issue, I also strongly recommend that you enable the **_Dependabot security updates_** option on [Code security and analysis](https://github.com/sourcegraph/jsonrpc2/settings/security_analysis) to receive out of schedule upgrades in case of a new security patch is released (avoiding being exposed for much time).

Thanks!