### PR TITLE
conn: delete from pending on close

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -173,8 +173,9 @@ func (c *Conn) close(cause error) error {
 		return ErrClosed
 	}
 
-	for _, call := range c.pending {
+	for id, call := range c.pending {
 		close(call.done)
+		delete(c.pending, id)
 	}
 
 	if cause != nil && cause != io.EOF && cause != io.ErrUnexpectedEOF {


### PR DESCRIPTION
If we close the connection while a response is yet to be processed, we close `call.done` and then try to send on it, leading to panic.
Making sure if we have closed the call, we also remove it from pending.