### PR TITLE
Use errors.Is/errors.As instead of == comparisons against errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -190,7 +190,7 @@ func (c *Conn) close(cause error) error {
 		close(call.done)
 	}
 
-	if cause != nil && cause != io.EOF && cause != io.ErrUnexpectedEOF {
+	if cause != nil && !errors.Is(cause, io.EOF) && !errors.Is(cause, io.ErrUnexpectedEOF) {
 		c.logger.Printf("jsonrpc2: protocol error: %v\n", cause)
 	}
 

--- a/handler_with_error.go
+++ b/handler_with_error.go
@@ -2,6 +2,7 @@ package jsonrpc2
 
 import (
 	"context"
+	"errors"
 )
 
 // HandlerWithError implements Handler by calling the func for each
@@ -31,14 +32,15 @@ func (h *HandlerWithErrorConfigurer) Handle(ctx context.Context, conn *Conn, req
 		err = resp.SetResult(result)
 	}
 
-	if e, ok := err.(*Error); ok {
+	var e *Error
+	if errors.As(err, &e) {
 		resp.Error = e
 	} else if err != nil {
 		resp.Error = &Error{Message: err.Error()}
 	}
 
 	err = conn.SendResponse(ctx, resp)
-	if err != nil && (err != ErrClosed || !h.suppressErrClosed) {
+	if err != nil && (!errors.Is(err, ErrClosed) || !h.suppressErrClosed) {
 		conn.logger.Printf("jsonrpc2 handler: sending response %s: %v\n", resp.ID, err)
 	}
 }

--- a/websocket/stream.go
+++ b/websocket/stream.go
@@ -3,6 +3,7 @@
 package websocket
 
 import (
+	"errors"
 	"io"
 
 	ws "github.com/gorilla/websocket"
@@ -28,7 +29,8 @@ func (t ObjectStream) WriteObject(obj interface{}) error {
 // ReadObject implements jsonrpc2.ObjectStream.
 func (t ObjectStream) ReadObject(v interface{}) error {
 	err := t.conn.ReadJSON(v)
-	if e, ok := err.(*ws.CloseError); ok {
+	var e *ws.CloseError
+	if errors.As(err, &e) {
 		if e.Code == ws.CloseAbnormalClosure && e.Text == io.ErrUnexpectedEOF.Error() {
 			// Suppress a noisy (but harmless) log message by
 			// unwrapping this error.


### PR DESCRIPTION
This change replaces direct `==`/`!=` comparisons against error values with the
standard library helpers `errors.Is` (for sentinel error values) and `errors.As`
(for error types).

Direct comparison breaks when an error is wrapped (e.g. with `fmt.Errorf("...: %w", err)`),
whereas `errors.Is`/`errors.As` traverse the wrap chain.

Notes:
- Comparisons against `nil` are intentionally left unchanged.
- Test files, vendored code, and generated code were not modified.

[_Created by Sourcegraph batch change `bahrmichael/432ac474-d2a7-4950-b17f-2a1b1fe59e87`._](https://sourcegraph.sourcegraph.com/users/bahrmichael/batch-changes/432ac474-d2a7-4950-b17f-2a1b1fe59e87)