### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.16
+          - 1.26.4
     name: Go ${{ matrix.go }}
     runs-on: ubuntu-latest
     steps:

--- a/call_opt.go
+++ b/call_opt.go
@@ -13,7 +13,7 @@ func (c callOptionFunc) apply(r *Request) error { return c(r) }
 // Meta returns a call option which attaches the given meta object to
 // the JSON-RPC 2.0 request (this is a Sourcegraph extension to JSON
 // RPC 2.0 for carrying metadata).
-func Meta(meta interface{}) CallOption {
+func Meta(meta any) CallOption {
 	return callOptionFunc(func(r *Request) error {
 		return r.SetMeta(meta)
 	})
@@ -22,7 +22,7 @@ func Meta(meta interface{}) CallOption {
 // ExtraField returns a call option which attaches the given name/value pair to
 // the JSON-RPC 2.0 request. This can be used to add arbitrary extensions to
 // JSON RPC 2.0.
-func ExtraField(name string, value interface{}) CallOption {
+func ExtraField(name string, value any) CallOption {
 	return callOptionFunc(func(r *Request) error {
 		return r.SetExtraField(name, value)
 	})

--- a/call_opt_test.go
+++ b/call_opt_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestPickID(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	a, b := inMemoryPeerConns()
 	defer a.Close()
@@ -27,7 +26,7 @@ func TestPickID(t *testing.T) {
 	defer connB.Close()
 
 	const n = 100
-	for i := 0; i < n; i++ {
+	for i := range n {
 		var opts []jsonrpc2.CallOption
 		id := jsonrpc2.ID{Num: uint64(i)}
 
@@ -54,8 +53,7 @@ func TestPickID(t *testing.T) {
 
 func TestStringID(t *testing.T) {
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	a, b := inMemoryPeerConns()
 	defer a.Close()
@@ -93,8 +91,7 @@ func TestStringID(t *testing.T) {
 
 func TestExtraField(t *testing.T) {
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	a, b := inMemoryPeerConns()
 	defer a.Close()

--- a/conn.go
+++ b/conn.go
@@ -86,7 +86,7 @@ func (c *Conn) Close() error {
 // waits for the response. If the response is successful, its result is stored
 // in result (a pointer to a value that can be JSON-unmarshaled into);
 // otherwise, a non-nil error is returned. See DispatchCall for more details.
-func (c *Conn) Call(ctx context.Context, method string, params, result interface{}, opts ...CallOption) error {
+func (c *Conn) Call(ctx context.Context, method string, params, result any, opts ...CallOption) error {
 	call, err := c.DispatchCall(ctx, method, params, opts...)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (c *Conn) DisconnectNotify() <-chan struct{} {
 // The params member is omitted from the JSON-RPC request if the given params is
 // nil. Use json.RawMessage("null") to send a JSON-RPC request with its params
 // member set to null.
-func (c *Conn) DispatchCall(ctx context.Context, method string, params interface{}, opts ...CallOption) (Waiter, error) {
+func (c *Conn) DispatchCall(ctx context.Context, method string, params any, opts ...CallOption) (Waiter, error) {
 	req := &Request{Method: method}
 	for _, opt := range opts {
 		if opt == nil {
@@ -137,7 +137,7 @@ func (c *Conn) DispatchCall(ctx context.Context, method string, params interface
 // The params member is omitted from the JSON-RPC request if the given params is
 // nil. Use json.RawMessage("null") to send a JSON-RPC request with its params
 // member set to null.
-func (c *Conn) Notify(ctx context.Context, method string, params interface{}, opts ...CallOption) error {
+func (c *Conn) Notify(ctx context.Context, method string, params any, opts ...CallOption) error {
 	req := &Request{Method: method, Notif: true}
 	for _, opt := range opts {
 		if opt == nil {
@@ -157,7 +157,7 @@ func (c *Conn) Notify(ctx context.Context, method string, params interface{}, op
 }
 
 // Reply sends a successful response with a result.
-func (c *Conn) Reply(ctx context.Context, id ID, result interface{}) error {
+func (c *Conn) Reply(ctx context.Context, id ID, result any) error {
 	resp := &Response{ID: id}
 	if err := resp.SetResult(result); err != nil {
 		return err
@@ -346,7 +346,7 @@ type Waiter struct {
 // is successful, its result is stored in result (a pointer to a
 // value that can be JSON-unmarshaled into); otherwise, a non-nil
 // error is returned.
-func (w Waiter) Wait(ctx context.Context, result interface{}) error {
+func (w Waiter) Wait(ctx context.Context, result any) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -380,7 +380,7 @@ type anyMessage struct {
 }
 
 func (m anyMessage) MarshalJSON() ([]byte, error) {
-	var v interface{}
+	var v any
 	switch {
 	case m.request != nil && m.response == nil:
 		v = m.request
@@ -397,10 +397,10 @@ func (m *anyMessage) UnmarshalJSON(data []byte) error {
 	// The presence of these fields distinguishes between the 2
 	// message types.
 	type msg struct {
-		ID     interface{}              `json:"id"`
+		ID     any                      `json:"id"`
 		Method *string                  `json:"method"`
 		Result anyValueWithExplicitNull `json:"result"`
-		Error  interface{}              `json:"error"`
+		Error  any                      `json:"error"`
 	}
 
 	var isRequest, isResponse bool
@@ -441,7 +441,7 @@ func (m *anyMessage) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	var v interface{}
+	var v any
 	switch {
 	case isRequest && !isResponse:
 		v = &m.request
@@ -461,7 +461,7 @@ func (m *anyMessage) UnmarshalJSON(data []byte) error {
 // {"result":null} by anyMessage's JSON unmarshaler.
 type anyValueWithExplicitNull struct {
 	null  bool // JSON "null"
-	value interface{}
+	value any
 }
 
 func (v anyValueWithExplicitNull) MarshalJSON() ([]byte, error) {

--- a/conn_opt.go
+++ b/conn_opt.go
@@ -8,7 +8,7 @@ import (
 // Logger interface implements one method - Printf.
 // You can use the stdlib logger *log.Logger
 type Logger interface {
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 // ConnOpt is the type of function that can be passed to NewConn to

--- a/conn_opt_test.go
+++ b/conn_opt_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestSetLogger(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	rd, wr := io.Pipe()
 	defer rd.Close()
@@ -67,8 +66,7 @@ func (h *dummyHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jso
 }
 
 func TestLogMessages(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	rd, wr := io.Pipe()
 	defer rd.Close()

--- a/conn_test.go
+++ b/conn_test.go
@@ -67,7 +67,7 @@ func TestConn(t *testing.T) {
 }
 
 var paramsTests = []struct {
-	sendParams interface{}
+	sendParams any
 	wantParams *json.RawMessage
 }{
 	{
@@ -220,8 +220,7 @@ func TestConn_Close(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			connA, connB := net.Pipe()
 			nodeA := jsonrpc2.NewConn(

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sourcegraph/jsonrpc2
 
-go 1.12
+go 1.26.4
 
 require github.com/gorilla/websocket v1.4.1

--- a/handler_with_error.go
+++ b/handler_with_error.go
@@ -6,13 +6,13 @@ import (
 
 // HandlerWithError implements Handler by calling the func for each
 // request and handling returned errors and results.
-func HandlerWithError(handleFunc func(context.Context, *Conn, *Request) (result interface{}, err error)) *HandlerWithErrorConfigurer {
+func HandlerWithError(handleFunc func(context.Context, *Conn, *Request) (result any, err error)) *HandlerWithErrorConfigurer {
 	return &HandlerWithErrorConfigurer{handleFunc: handleFunc}
 }
 
 // HandlerWithErrorConfigurer is a handler created by HandlerWithError.
 type HandlerWithErrorConfigurer struct {
-	handleFunc        func(context.Context, *Conn, *Request) (result interface{}, err error)
+	handleFunc        func(context.Context, *Conn, *Request) (result any, err error)
 	suppressErrClosed bool
 }
 

--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -16,10 +16,10 @@ import (
 // an API boundary.
 type JSONRPC2 interface {
 	// Call issues a standard request (http://www.jsonrpc.org/specification#request_object).
-	Call(ctx context.Context, method string, params, result interface{}, opt ...CallOption) error
+	Call(ctx context.Context, method string, params, result any, opt ...CallOption) error
 
 	// Notify issues a notification request (http://www.jsonrpc.org/specification#notification).
-	Notify(ctx context.Context, method string, params interface{}, opt ...CallOption) error
+	Notify(ctx context.Context, method string, params any, opt ...CallOption) error
 
 	// Close closes the underlying connection, if it exists.
 	Close() error
@@ -34,7 +34,7 @@ type Error struct {
 
 // SetError sets e.Data to the JSON encoding of v. If JSON
 // marshaling fails, it panics.
-func (e *Error) SetError(v interface{}) {
+func (e *Error) SetError(v any) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		panic("Error.SetData: " + err.Error())

--- a/jsonrpc2_test.go
+++ b/jsonrpc2_test.go
@@ -213,7 +213,7 @@ func testClientServer(ctx context.Context, t *testing.T, stream jsonrpc2.ObjectS
 
 	// Simple
 	const n = 100
-	for i := 0; i < n; i++ {
+	for i := range n {
 		var got string
 		if err := cc.Call(ctx, "f", []int32{1, 2, 3}, &got); err != nil {
 			t.Fatal(err)
@@ -268,8 +268,7 @@ func TestHandlerBlocking(t *testing.T) {
 	// We send N notifications with an increasing parameter. Since the
 	// handler is blocking, we expect to process the notifications in the
 	// order they are sent.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	a, b := inMemoryPeerConns()
 	defer a.Close()
@@ -291,7 +290,7 @@ func TestHandlerBlocking(t *testing.T) {
 	defer connB.Close()
 
 	const n = 100
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		if err := connB.Notify(ctx, "f", i); err != nil {
 			t.Fatal(err)

--- a/request.go
+++ b/request.go
@@ -33,7 +33,7 @@ type Request struct {
 // MarshalJSON implements json.Marshaler and adds the "jsonrpc":"2.0"
 // property.
 func (r Request) MarshalJSON() ([]byte, error) {
-	r2 := map[string]interface{}{
+	r2 := map[string]any{
 		"jsonrpc": "2.0",
 		"method":  r.Method,
 	}
@@ -54,8 +54,8 @@ func (r Request) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (r *Request) UnmarshalJSON(data []byte) error {
-	r2 := make(map[string]interface{})
-	pop := func(key string) interface{} {
+	r2 := make(map[string]any)
+	pop := func(key string) any {
 		defer delete(r2, key)
 		return r2[key]
 	}
@@ -136,7 +136,7 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 
 // SetParams sets r.Params to the JSON encoding of v. If JSON
 // marshaling fails, it returns an error.
-func (r *Request) SetParams(v interface{}) error {
+func (r *Request) SetParams(v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ func (r *Request) SetParams(v interface{}) error {
 
 // SetMeta sets r.Meta to the JSON encoding of v. If JSON
 // marshaling fails, it returns an error.
-func (r *Request) SetMeta(v interface{}) error {
+func (r *Request) SetMeta(v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func (r *Request) SetMeta(v interface{}) error {
 // SetExtraField adds an entry to r.ExtraFields, so that it is added to the
 // JSON encoding of the request, as a way to add arbitrary extensions to
 // JSON RPC 2.0. If JSON marshaling fails, it returns an error.
-func (r *Request) SetExtraField(name string, v interface{}) error {
+func (r *Request) SetExtraField(name string, v any) error {
 	switch name {
 	case "id", "jsonrpc", "meta", "method", "params":
 		return fmt.Errorf("invalid extra field %q", name)
@@ -174,5 +174,5 @@ func (r *Request) SetExtraField(name string, v interface{}) error {
 // RequestField is a top-level field that can be added to the JSON-RPC request.
 type RequestField struct {
 	Name  string
-	Value interface{}
+	Value any
 }

--- a/response.go
+++ b/response.go
@@ -62,7 +62,7 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 
 // SetResult sets r.Result to the JSON representation of v. If JSON
 // marshaling fails, it returns an error.
-func (r *Response) SetResult(v interface{}) error {
+func (r *Response) SetResult(v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err

--- a/stream.go
+++ b/stream.go
@@ -14,11 +14,11 @@ import (
 // An ObjectStream is a bidirectional stream of JSON-RPC 2.0 objects.
 type ObjectStream interface {
 	// WriteObject writes a JSON-RPC 2.0 object to the stream.
-	WriteObject(obj interface{}) error
+	WriteObject(obj any) error
 
 	// ReadObject reads the next JSON-RPC 2.0 object from the stream
 	// and stores it in the value pointed to by v.
-	ReadObject(v interface{}) error
+	ReadObject(v any) error
 
 	io.Closer
 }
@@ -55,7 +55,7 @@ func NewBufferedStream(conn io.ReadWriteCloser, codec ObjectCodec) ObjectStream 
 }
 
 // WriteObject implements ObjectStream.
-func (t *bufferedObjectStream) WriteObject(obj interface{}) error {
+func (t *bufferedObjectStream) WriteObject(obj any) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if err := t.codec.WriteObject(t.w, obj); err != nil {
@@ -65,7 +65,7 @@ func (t *bufferedObjectStream) WriteObject(obj interface{}) error {
 }
 
 // ReadObject implements ObjectStream.
-func (t *bufferedObjectStream) ReadObject(v interface{}) error {
+func (t *bufferedObjectStream) ReadObject(v any) error {
 	return t.codec.ReadObject(t.r, v)
 }
 
@@ -78,11 +78,11 @@ func (t *bufferedObjectStream) Close() error {
 // object in a stream.
 type ObjectCodec interface {
 	// WriteObject writes a JSON-RPC 2.0 object to the stream.
-	WriteObject(stream io.Writer, obj interface{}) error
+	WriteObject(stream io.Writer, obj any) error
 
 	// ReadObject reads the next JSON-RPC 2.0 object from the stream
 	// and stores it in the value pointed to by v.
-	ReadObject(stream *bufio.Reader, v interface{}) error
+	ReadObject(stream *bufio.Reader, v any) error
 }
 
 // VarintObjectCodec reads/writes JSON-RPC 2.0 objects with a varint
@@ -90,7 +90,7 @@ type ObjectCodec interface {
 type VarintObjectCodec struct{}
 
 // WriteObject implements ObjectCodec.
-func (VarintObjectCodec) WriteObject(stream io.Writer, obj interface{}) error {
+func (VarintObjectCodec) WriteObject(stream io.Writer, obj any) error {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (VarintObjectCodec) WriteObject(stream io.Writer, obj interface{}) error {
 }
 
 // ReadObject implements ObjectCodec.
-func (VarintObjectCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
+func (VarintObjectCodec) ReadObject(stream *bufio.Reader, v any) error {
 	b, err := binary.ReadUvarint(stream)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func (VarintObjectCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
 type VSCodeObjectCodec struct{}
 
 // WriteObject implements ObjectCodec.
-func (VSCodeObjectCodec) WriteObject(stream io.Writer, obj interface{}) error {
+func (VSCodeObjectCodec) WriteObject(stream io.Writer, obj any) error {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func (VSCodeObjectCodec) WriteObject(stream io.Writer, obj interface{}) error {
 }
 
 // ReadObject implements ObjectCodec.
-func (VSCodeObjectCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
+func (VSCodeObjectCodec) ReadObject(stream *bufio.Reader, v any) error {
 	var contentLength uint64
 	for {
 		line, err := stream.ReadString('\r')
@@ -153,8 +153,8 @@ func (VSCodeObjectCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
 		if line == "\r" {
 			break
 		}
-		if strings.HasPrefix(line, "Content-Length: ") {
-			line = strings.TrimPrefix(line, "Content-Length: ")
+		if after, ok := strings.CutPrefix(line, "Content-Length: "); ok {
+			line = after
 			line = strings.TrimSpace(line)
 			var err error
 			contentLength, err = strconv.ParseUint(line, 10, 32)
@@ -178,7 +178,7 @@ type PlainObjectCodec struct {
 }
 
 // WriteObject implements ObjectCodec.
-func (c PlainObjectCodec) WriteObject(stream io.Writer, v interface{}) error {
+func (c PlainObjectCodec) WriteObject(stream io.Writer, v any) error {
 	if c.encoder != nil {
 		return c.encoder.Encode(v)
 	}
@@ -186,7 +186,7 @@ func (c PlainObjectCodec) WriteObject(stream io.Writer, v interface{}) error {
 }
 
 // ReadObject implements ObjectCodec.
-func (c PlainObjectCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
+func (c PlainObjectCodec) ReadObject(stream *bufio.Reader, v any) error {
 	if c.decoder != nil {
 		return c.decoder.Decode(v)
 	}
@@ -211,13 +211,13 @@ func NewPlainObjectStream(conn io.ReadWriteCloser) ObjectStream {
 	}
 }
 
-func (os *plainObjectStream) ReadObject(v interface{}) error {
+func (os *plainObjectStream) ReadObject(v any) error {
 	return os.decoder.Decode(v)
 }
 
 // WriteObject serializes a value to JSON and writes it to a stream.
 // Not thread-safe, a user must synchronize writes in a multithreaded environment.
-func (os *plainObjectStream) WriteObject(v interface{}) error {
+func (os *plainObjectStream) WriteObject(v any) error {
 	return os.encoder.Encode(v)
 }
 

--- a/websocket/stream.go
+++ b/websocket/stream.go
@@ -21,12 +21,12 @@ func NewObjectStream(conn *ws.Conn) ObjectStream {
 }
 
 // WriteObject implements jsonrpc2.ObjectStream.
-func (t ObjectStream) WriteObject(obj interface{}) error {
+func (t ObjectStream) WriteObject(obj any) error {
 	return t.conn.WriteJSON(obj)
 }
 
 // ReadObject implements jsonrpc2.ObjectStream.
-func (t ObjectStream) ReadObject(v interface{}) error {
+func (t ObjectStream) ReadObject(v any) error {
 	err := t.conn.ReadJSON(v)
 	if e, ok := err.(*ws.CloseError); ok {
 		if e.Code == ws.CloseAbnormalClosure && e.Text == io.ErrUnexpectedEOF.Error() {


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)